### PR TITLE
Add option to pass state and context as a dict to the agent

### DIFF
--- a/src/envs/box2d/carl_bipedal_walker.py
+++ b/src/envs/box2d/carl_bipedal_walker.py
@@ -129,6 +129,7 @@ class CARLBipedalWalkerEnv(CARLEnv):
             scale_context_features: str = "no",
             default_context: Optional[Dict] = DEFAULT_CONTEXT,
             state_context_features: Optional[List[str]] = None,
+            dict_observation_space: bool = False,
     ):
         """
 
@@ -155,6 +156,7 @@ class CARLBipedalWalkerEnv(CARLEnv):
             scale_context_features=scale_context_features,
             default_context=default_context,
             state_context_features=state_context_features,
+            dict_observation_space=dict_observation_space
 
         )
         self.whitelist_gaussian_noise = list(DEFAULT_CONTEXT.keys())  # allow to augment all values

--- a/src/envs/box2d/carl_lunarlander.py
+++ b/src/envs/box2d/carl_lunarlander.py
@@ -141,7 +141,8 @@ class CARLLunarLanderEnv(CARLEnv):
             default_context: Optional[Dict] = DEFAULT_CONTEXT,
             state_context_features: Optional[List[str]] = None,
             max_episode_length: int = 1000,
-            high_gameover_penalty: bool = False
+            high_gameover_penalty: bool = False,
+            dict_observation_space: bool = False,
     ):
         """
 
@@ -170,6 +171,7 @@ class CARLLunarLanderEnv(CARLEnv):
             default_context=default_context,
             state_context_features=state_context_features,
             max_episode_length=max_episode_length,
+            dict_observation_space=dict_observation_space
         )
         self.whitelist_gaussian_noise = list(DEFAULT_CONTEXT.keys())  # allow to augment all values
 

--- a/src/envs/box2d/carl_vehicle_racing.py
+++ b/src/envs/box2d/carl_vehicle_racing.py
@@ -200,6 +200,7 @@ class CARLVehicleRacingEnv(CARLEnv):
             scale_context_features: str = "no",
             default_context: Optional[Dict] = DEFAULT_CONTEXT,
             state_context_features: Optional[List[str]] = None,
+            dict_observation_space: bool = False,
     ):
         """
 
@@ -231,6 +232,7 @@ class CARLVehicleRacingEnv(CARLEnv):
             scale_context_features=scale_context_features,
             default_context=default_context,
             state_context_features=state_context_features,
+            dict_observation_space=dict_observation_space
         )
         self.whitelist_gaussian_noise = [k for k in DEFAULT_CONTEXT.keys() if k not in CATEGORICAL_CONTEXT_FEATURES]
 

--- a/src/envs/brax/carl_ant.py
+++ b/src/envs/brax/carl_ant.py
@@ -45,6 +45,7 @@ class CARLAnt(CARLEnv):
             scale_context_features: str = "no",
             default_context: Optional[Dict] = DEFAULT_CONTEXT,
             state_context_features: Optional[List[str]] = None,
+            dict_observation_space: bool = False,
 
     ):
         env = GymWrapper(env)
@@ -62,6 +63,7 @@ class CARLAnt(CARLEnv):
             scale_context_features=scale_context_features,
             default_context=default_context,
             state_context_features=state_context_features,
+            dict_observation_space=dict_observation_space
         )
         self.whitelist_gaussian_noise = list(DEFAULT_CONTEXT.keys())  # allow to augment all values
 

--- a/src/envs/brax/carl_fetch.py
+++ b/src/envs/brax/carl_fetch.py
@@ -49,6 +49,7 @@ class CARLFetch(CARLEnv):
             scale_context_features: str = "no",
             default_context: Optional[Dict] = DEFAULT_CONTEXT,
             state_context_features: Optional[List[str]] = None,
+            dict_observation_space: bool = False,
     ):
         env = GymWrapper(env)
         self.base_config = MessageToDict(text_format.Parse(_SYSTEM_CONFIG, brax.Config()))
@@ -65,6 +66,7 @@ class CARLFetch(CARLEnv):
             scale_context_features=scale_context_features,
             default_context=default_context,
             state_context_features=state_context_features,
+            dict_observation_space=dict_observation_space
         )
         self.whitelist_gaussian_noise = list(DEFAULT_CONTEXT.keys())  # allow to augment all values
 

--- a/src/envs/brax/carl_grasp.py
+++ b/src/envs/brax/carl_grasp.py
@@ -49,6 +49,7 @@ class CARLGrasp(CARLEnv):
             scale_context_features: str = "no",
             default_context: Optional[Dict] = DEFAULT_CONTEXT,
             state_context_features: Optional[List[str]] = None,
+            dict_observation_space: bool = False,
     ):
         env = GymWrapper(env)
         self.base_config = MessageToDict(text_format.Parse(_SYSTEM_CONFIG, brax.Config()))
@@ -65,6 +66,7 @@ class CARLGrasp(CARLEnv):
             scale_context_features=scale_context_features,
             default_context=default_context,
             state_context_features=state_context_features,
+            dict_observation_space=dict_observation_space
         )
         self.whitelist_gaussian_noise = list(DEFAULT_CONTEXT.keys())  # allow to augment all values
 

--- a/src/envs/brax/carl_halfcheetah.py
+++ b/src/envs/brax/carl_halfcheetah.py
@@ -43,6 +43,7 @@ class CARLHalfcheetah(CARLEnv):
             scale_context_features: str = "no",
             default_context: Optional[Dict] = DEFAULT_CONTEXT,
             state_context_features: Optional[List[str]] = None,
+            dict_observation_space: bool = False,
     ):
         env = GymWrapper(env)
         self.base_config = MessageToDict(text_format.Parse(_SYSTEM_CONFIG, brax.Config()))
@@ -59,6 +60,7 @@ class CARLHalfcheetah(CARLEnv):
             scale_context_features=scale_context_features,
             default_context=default_context,
             state_context_features=state_context_features,
+            dict_observation_space=dict_observation_space
         )
         self.whitelist_gaussian_noise = list(DEFAULT_CONTEXT.keys())  # allow to augment all values
 

--- a/src/envs/brax/carl_humanoid.py
+++ b/src/envs/brax/carl_humanoid.py
@@ -4,7 +4,7 @@ import json
 
 import brax
 from brax.physics import bodies
-from brax.physics.base import take
+import jax.numpy as jnp
 from brax.envs.wrappers import GymWrapper
 from brax.envs.humanoid import Humanoid, _SYSTEM_CONFIG
 
@@ -45,6 +45,7 @@ class CARLHumanoid(CARLEnv):
             scale_context_features: str = "no",
             default_context: Optional[Dict] = DEFAULT_CONTEXT,
             state_context_features: Optional[List[str]] = None,
+            dict_observation_space: bool = False,
     ):
         env = GymWrapper(env)
         self.base_config = MessageToDict(text_format.Parse(_SYSTEM_CONFIG, brax.Config()))
@@ -61,6 +62,7 @@ class CARLHumanoid(CARLEnv):
             scale_context_features=scale_context_features,
             default_context=default_context,
             state_context_features=state_context_features,
+            dict_observation_space=dict_observation_space
         )
         self.whitelist_gaussian_noise = list(DEFAULT_CONTEXT.keys())  # allow to augment all values
 
@@ -76,7 +78,7 @@ class CARLHumanoid(CARLEnv):
         protobuf_config = json_format.Parse(json.dumps(config, cls=NumpyEncoder), brax.Config())
         self.env.sys = brax.System(protobuf_config)
         body = bodies.Body.from_config(protobuf_config)
-        body = take(body, body.idx[:-1])  # skip the floor body
+        body = jnp.take(body, body.idx[:-1])  # skip the floor body
         self.env.mass = body.mass.reshape(-1, 1)
         self.env.inertia = body.inertia
 

--- a/src/envs/brax/carl_ur5e.py
+++ b/src/envs/brax/carl_ur5e.py
@@ -49,6 +49,7 @@ class CARLUr5e(CARLEnv):
             scale_context_features: str = "no",
             default_context: Optional[Dict] = DEFAULT_CONTEXT,
             state_context_features: Optional[List[str]] = None,
+            dict_observation_space: bool = False,
     ):
         env = GymWrapper(env)
         self.base_config = MessageToDict(text_format.Parse(_SYSTEM_CONFIG, brax.Config()))
@@ -65,6 +66,7 @@ class CARLUr5e(CARLEnv):
             scale_context_features=scale_context_features,
             default_context=default_context,
             state_context_features=state_context_features,
+            dict_observation_space=dict_observation_space
         )
         self.whitelist_gaussian_noise = list(DEFAULT_CONTEXT.keys())  # allow to augment all values
 

--- a/src/envs/classic_control/carl_acrobot.py
+++ b/src/envs/classic_control/carl_acrobot.py
@@ -46,6 +46,7 @@ class CARLAcrobotEnv(CARLEnv):
             default_context: Optional[Dict] = DEFAULT_CONTEXT,
             max_episode_length: int = 500,  # from https://github.com/openai/gym/blob/master/gym/envs/__init__.py
             state_context_features: Optional[List[str]] = None,
+            dict_observation_space: bool = False,
     ):
         if not contexts:
             contexts = {0: DEFAULT_CONTEXT}
@@ -61,6 +62,7 @@ class CARLAcrobotEnv(CARLEnv):
             default_context=default_context,
             max_episode_length=max_episode_length,
             state_context_features=state_context_features,
+            dict_observation_space=dict_observation_space
         )
         self.whitelist_gaussian_noise = list(DEFAULT_CONTEXT.keys())  # allow to augment all values
 

--- a/src/envs/classic_control/carl_cartpole.py
+++ b/src/envs/classic_control/carl_cartpole.py
@@ -38,6 +38,7 @@ class CARLCartPoleEnv(CARLEnv):
             default_context: Optional[Dict] = DEFAULT_CONTEXT,
             max_episode_length: int = 500,  # from https://github.com/openai/gym/blob/master/gym/envs/__init__.py
             state_context_features: Optional[List[str]] = None,
+            dict_observation_space: bool = False,
     ):
         if not contexts:
             contexts = {0: DEFAULT_CONTEXT}
@@ -53,6 +54,7 @@ class CARLCartPoleEnv(CARLEnv):
             default_context=default_context,
             max_episode_length=max_episode_length,
             state_context_features=state_context_features,
+            dict_observation_space=dict_observation_space
         )
         self.whitelist_gaussian_noise = list(DEFAULT_CONTEXT.keys())  # allow to augment all values
 

--- a/src/envs/classic_control/carl_mountaincar.py
+++ b/src/envs/classic_control/carl_mountaincar.py
@@ -87,6 +87,7 @@ class CARLMountainCarEnv(CARLEnv):
             default_context: Optional[Dict] = DEFAULT_CONTEXT,
             max_episode_length: int = 200,  # from https://github.com/openai/gym/blob/master/gym/envs/__init__.py
             state_context_features: Optional[List[str]] = None,
+            dict_observation_space: bool = False,
     ):
         """
 
@@ -112,6 +113,7 @@ class CARLMountainCarEnv(CARLEnv):
             default_context=default_context,
             max_episode_length=max_episode_length,
             state_context_features=state_context_features,
+            dict_observation_space=dict_observation_space
         )
         self.whitelist_gaussian_noise = list(DEFAULT_CONTEXT.keys())  # allow to augment all values
 

--- a/src/envs/classic_control/carl_mountaincarcontinuous.py
+++ b/src/envs/classic_control/carl_mountaincarcontinuous.py
@@ -66,6 +66,7 @@ class CARLMountainCarContinuousEnv(CARLEnv):
             default_context: Optional[Dict] = DEFAULT_CONTEXT,
             max_episode_length: int = 999,  # from https://github.com/openai/gym/blob/master/gym/envs/__init__.py
             state_context_features: Optional[List[str]] = None,
+            dict_observation_space: bool = False,
     ):
         """
 
@@ -91,6 +92,7 @@ class CARLMountainCarContinuousEnv(CARLEnv):
             default_context=default_context,
             max_episode_length=max_episode_length,
             state_context_features = state_context_features,
+            dict_observation_space=dict_observation_space
         )
         self.whitelist_gaussian_noise = list(DEFAULT_CONTEXT.keys())  # allow to augment all values
 

--- a/src/envs/classic_control/carl_pendulum.py
+++ b/src/envs/classic_control/carl_pendulum.py
@@ -38,6 +38,7 @@ class CARLPendulumEnv(CARLEnv):
             default_context: Optional[Dict] = DEFAULT_CONTEXT,
             max_episode_length: int = 200,  # from https://github.com/openai/gym/blob/master/gym/envs/__init__.py
             state_context_features: Optional[List[str]] = None,
+            dict_observation_space: bool = False,
     ):
         """
         Max torque is not a context feature because it changes the action space.
@@ -65,6 +66,7 @@ class CARLPendulumEnv(CARLEnv):
             default_context=default_context,
             max_episode_length=max_episode_length,
             state_context_features=state_context_features,
+            dict_observation_space=dict_observation_space
         )
         self.whitelist_gaussian_noise = list(DEFAULT_CONTEXT.keys())  # allow to augment all values
 

--- a/src/envs/mario/carl_mario.py
+++ b/src/envs/mario/carl_mario.py
@@ -39,6 +39,7 @@ class CARLMarioEnv(CARLEnv):
         scale_context_features: str = "no",
         default_context: Optional[Dict] = DEFAULT_CONTEXT,
         state_context_features: Optional[List[str]] = None,
+        dict_observation_space: bool = False,
     ):
         if not contexts:
             contexts = {0: DEFAULT_CONTEXT}
@@ -52,6 +53,7 @@ class CARLMarioEnv(CARLEnv):
             logger=logger,
             scale_context_features="no",
             default_context=default_context,
+            dict_observation_space=dict_observation_space
         )
         self.levels = []
         self._update_context()

--- a/src/envs/rna/carl_rna.py
+++ b/src/envs/rna/carl_rna.py
@@ -34,7 +34,7 @@ class CARLRnaDesignEnv(CARLEnv):
             gaussian_noise_std_percentage: float = 0.01,
             logger: Optional[TrialLogger] = None,
             scale_context_features: str = "no",
-            default_context: Optional[Dict] = DEFAULT_CONTEXT,
+            default_context: Optional[Dict] = DEFAULT_CONTEXT
     ):
         """
 
@@ -76,7 +76,7 @@ class CARLRnaDesignEnv(CARLEnv):
             gaussian_noise_std_percentage=gaussian_noise_std_percentage,
             logger=logger,
             scale_context_features=scale_context_features,
-            default_context=default_context,
+            default_context=default_context
         )
         self.whitelist_gaussian_noise = list(DEFAULT_CONTEXT)
 

--- a/src/tests/test_CARLEnv.py
+++ b/src/tests/test_CARLEnv.py
@@ -130,6 +130,26 @@ class TestStateConstruction(unittest.TestCase):
         # state should be of length 5 because two features are changing (dt and l)
         self.assertEqual(5, len(state))
 
+    def test_dict_observation_space(self):
+        contexts = {
+            "0": {"max_speed": 8., "dt":  0.03, "g": 10.0, "m": 1., "l": 1.}
+        }
+        env = CARLPendulumEnv(
+            contexts=contexts,
+            hide_context=False,
+            dict_observation_space=True,
+            add_gaussian_noise_to_context=False,
+            gaussian_noise_std_percentage=0.01,
+            state_context_features=["changing_context_features"],
+        ) 
+        obs = env.reset()
+        self.assertEqual(type(obs), dict)
+        self.assertTrue("state" in obs)
+        self.assertTrue("context" in obs)
+        action = [0.01]  # torque
+        next_obs, reward, done, info = env.step(action=action)
+        env.close() 
+        
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds an `dict_observation_space` option to the `CARLEnv`. Instead of concatenating the state and context in each observation, they are passed to the agent as `state` and `context` entries in a dict.