### PR TITLE
Added context key property for CARLEnv

### DIFF
--- a/carl/envs/carl_env.py
+++ b/carl/envs/carl_env.py
@@ -193,9 +193,7 @@ class CARLEnv(Wrapper):
         # where it is allowed to add gaussian noise
 
         # Set initial context
-        self.context_index = 0  # type: int
-        context_keys = list(self.contexts.keys())
-        self.context = self.contexts[context_keys[self.context_index]]
+        self.context = self.context_selector.select()
 
         # Scale context features
         if scale_context_features not in self.available_scale_methods:
@@ -234,7 +232,7 @@ class CARLEnv(Wrapper):
 
     @property
     def context_key(self) -> str:
-        return list(self.contexts.keys())[self.context_index]
+        return self.context_selector.contexts_keys[self.context_selector.context_index]
 
     @context.setter
     def context(self, context: Context) -> None:

--- a/carl/envs/carl_env.py
+++ b/carl/envs/carl_env.py
@@ -232,6 +232,10 @@ class CARLEnv(Wrapper):
     def context(self) -> Dict:
         return self._context
 
+    @property
+    def context_key(self) -> str:
+        return list(self.contexts.keys())[self.context_index]
+
     @context.setter
     def context(self, context: Context) -> None:
         self._context = self.fill_context_with_default(context=context)


### PR DESCRIPTION
Allows to access the current context's key via a new `context_key` property