### PR TITLE
Replace redundant 'gravity' with 'max_speed' context feature to pendulum env

### DIFF
--- a/carl/envs/gymnasium/classic_control/carl_pendulum.py
+++ b/carl/envs/gymnasium/classic_control/carl_pendulum.py
@@ -15,8 +15,8 @@ class CARLPendulum(CARLGymnasiumEnv):
     @staticmethod
     def get_context_features() -> dict[str, ContextFeature]:
         return {
-            "gravity": UniformFloatContextFeature(
-                "gravity", lower=-np.inf, upper=np.inf, default_value=8.0
+            "max_speed": UniformFloatContextFeature(
+                "max_speed", lower=-np.inf, upper=np.inf, default_value=8.0
             ),
             "dt": UniformFloatContextFeature(
                 "dt", lower=0, upper=np.inf, default_value=0.05


### PR DESCRIPTION
The CARLPendulum class already defines the context feature `g` to update gravity.  The additional `gravity` context was likely a miswrite, since its default matched the intended `max_speed` context feature. This PR replaces `gravity` with `max_speed`